### PR TITLE
Feature/allow injection custom handler

### DIFF
--- a/Microsoft.Extensions.Hosting.Kafka.sln
+++ b/Microsoft.Extensions.Hosting.Kafka.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Extensions.Generic.Kafka.Ho
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Extensions.Generic.Kafka.Hosting.LowLevelKafkaMessageHandling", "samples\Extensions.Generic.Kafka.Hosting.LowLevelKafkaMessageHandling\Extensions.Generic.Kafka.Hosting.LowLevelKafkaMessageHandling.csproj", "{F1933DFA-5CBB-4FC9-9E6E-E7E0B7CB9348}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extensions.Generic.Kafka.Hosting.CustomHandle", "samples\Extensions.Generic.Kafka.Hosting.CustomHandle\Extensions.Generic.Kafka.Hosting.CustomHandle.csproj", "{B9F14410-40AB-4E8E-ADFB-A5FF1B4638E7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,18 @@ Global
 		{F1933DFA-5CBB-4FC9-9E6E-E7E0B7CB9348}.Release|x64.Build.0 = Release|Any CPU
 		{F1933DFA-5CBB-4FC9-9E6E-E7E0B7CB9348}.Release|x86.ActiveCfg = Release|Any CPU
 		{F1933DFA-5CBB-4FC9-9E6E-E7E0B7CB9348}.Release|x86.Build.0 = Release|Any CPU
+		{B9F14410-40AB-4E8E-ADFB-A5FF1B4638E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9F14410-40AB-4E8E-ADFB-A5FF1B4638E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9F14410-40AB-4E8E-ADFB-A5FF1B4638E7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B9F14410-40AB-4E8E-ADFB-A5FF1B4638E7}.Debug|x64.Build.0 = Debug|Any CPU
+		{B9F14410-40AB-4E8E-ADFB-A5FF1B4638E7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B9F14410-40AB-4E8E-ADFB-A5FF1B4638E7}.Debug|x86.Build.0 = Debug|Any CPU
+		{B9F14410-40AB-4E8E-ADFB-A5FF1B4638E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9F14410-40AB-4E8E-ADFB-A5FF1B4638E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9F14410-40AB-4E8E-ADFB-A5FF1B4638E7}.Release|x64.ActiveCfg = Release|Any CPU
+		{B9F14410-40AB-4E8E-ADFB-A5FF1B4638E7}.Release|x64.Build.0 = Release|Any CPU
+		{B9F14410-40AB-4E8E-ADFB-A5FF1B4638E7}.Release|x86.ActiveCfg = Release|Any CPU
+		{B9F14410-40AB-4E8E-ADFB-A5FF1B4638E7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -82,6 +96,7 @@ Global
 		{4FC61656-12AB-424A-813F-01C220D33118} = {F6145EBE-640C-42D1-B890-D76D3716912E}
 		{1EABE3AA-F1C7-4A12-AF9C-4BCFE9D842B9} = {F6145EBE-640C-42D1-B890-D76D3716912E}
 		{F1933DFA-5CBB-4FC9-9E6E-E7E0B7CB9348} = {F6145EBE-640C-42D1-B890-D76D3716912E}
+		{B9F14410-40AB-4E8E-ADFB-A5FF1B4638E7} = {F6145EBE-640C-42D1-B890-D76D3716912E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4A5FB2C0-313F-43E0-8B3A-FC63F7429784}

--- a/samples/Extensions.Generic.Kafka.Hosting.CustomHandle/Extensions.Generic.Kafka.Hosting.CustomHandle.csproj
+++ b/samples/Extensions.Generic.Kafka.Hosting.CustomHandle/Extensions.Generic.Kafka.Hosting.CustomHandle.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Extensions.Hosting.Kafka\Microsoft.Extensions.Hosting.Kafka.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Extensions.Generic.Kafka.Hosting.CustomHandle/HandleWithHeaders.cs
+++ b/samples/Extensions.Generic.Kafka.Hosting.CustomHandle/HandleWithHeaders.cs
@@ -1,0 +1,30 @@
+using System.Text;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Microsoft.Extensions.Hosting.Kafka;
+using Microsoft.Extensions.Logging;
+
+namespace Extensions.Generic.Kafka.Hosting.CustomHandle
+{
+    public class HandleWithHeaders : IKafkaMessageHandler<string, byte[]>
+    {
+        private readonly ILogger<HandleWithHeaders> logger;
+
+        public HandleWithHeaders(ILogger<HandleWithHeaders> logger)
+        {
+            this.logger = logger;
+        }
+
+        public Task Handle(ConsumeResult<string, byte[]> message)
+        {
+            if (message.Headers.TryGetLastBytes("traceId", out var traceIdBytes))
+            {
+                logger.LogInformation($"Received message with trace ID {Encoding.UTF8.GetString(traceIdBytes)} from Kafka {message.Key} : {Encoding.UTF8.GetString(message.Value)}");
+                return Task.CompletedTask;
+            }
+
+            logger.LogInformation($"Received message without trace ID from Kafka {message.Key} : {Encoding.UTF8.GetString(message.Value)}");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/samples/Extensions.Generic.Kafka.Hosting.CustomHandle/Program.cs
+++ b/samples/Extensions.Generic.Kafka.Hosting.CustomHandle/Program.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Kafka;
+using Microsoft.Extensions.Logging;
+
+namespace Extensions.Generic.Kafka.Hosting.CustomHandle
+{
+    class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            var host = new HostBuilder()
+                .UseConsoleLifetime()
+                .ConfigureAppConfiguration((hostContext, configApp) =>
+                {
+                    hostContext.HostingEnvironment.ApplicationName = "Sample Hostbuilder Custom Kafka Message Handler";
+                    hostContext.HostingEnvironment.ContentRootPath = Directory.GetCurrentDirectory();
+                })
+                .UseKafka<string, byte[], HandleWithHeaders>(config =>
+                {
+                    config.BootstrapServers = new[] { "kafka:9092" };
+                })
+                .ConfigureServices(container =>
+                {
+                    container.Configure<KafkaListenerSettings>(config =>
+                    {
+                        config.Topics = new[] { "topic1" };
+                        config.ConsumerGroup = "group1";
+                        config.AutoOffsetReset = "Latest";
+                        config.AutoCommitIntervall = 5000;
+                        config.IsAutocommitEnabled = true;
+                    });
+                })
+                .ConfigureLogging((ILoggingBuilder loggingBuilder) =>
+                {
+                    loggingBuilder.AddConsole();
+                    loggingBuilder.AddDebug();
+                })
+                .Build();
+
+            await host.RunAsync();
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Hosting.Kafka/Microsoft.Extensions.Hosting.Kafka.csproj
+++ b/src/Microsoft.Extensions.Hosting.Kafka/Microsoft.Extensions.Hosting.Kafka.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
-    <PackageReference Include="MinVer" Version="1.2.0">
+    <PackageReference Include="MinVer" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Added a method overload to use a custom handle to handle Kafka messages directly.
This way, all the message's information can be accessed without exposing and extending the rather simple forwarding handler.